### PR TITLE
fix for issue #5 HASS 2025.6 integration issue.

### DIFF
--- a/erie_watertreatment/__init__.py
+++ b/erie_watertreatment/__init__.py
@@ -85,9 +85,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await create_coordinator(hass, api)
     
     for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setups(entry, component)
-        )
+        await hass.async_create_task(
+                hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+       )
         
     return True
     

--- a/erie_watertreatment/__init__.py
+++ b/erie_watertreatment/__init__.py
@@ -86,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     
     for component in PLATFORMS:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
+            hass.config_entries.async_forward_entry_setups(entry, component)
         )
         
     return True


### PR DESCRIPTION
@tgebarowski Fix for the issue #5 by Tival Adam 

Due to depricated

`hass.config_entries.async_forward_entry_setup()`
it have to be changed to

```
await hass.async_create_task(
    hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
)
```
in __init__.py

